### PR TITLE
fix diagnostics notebook

### DIFF
--- a/priv/samples/debug/diagnostics.livemd
+++ b/priv/samples/debug/diagnostics.livemd
@@ -25,18 +25,21 @@ runtime_info()
 kv = Nerves.Runtime.KV.get_all()
 active = kv["nerves_fw_active"]
 
-data = Enum.group_by(kv, fn
+data =
+  Enum.group_by(kv, fn
     {<<^active::binary-1, ".", _::binary>>, _} -> :active
     {<<_::8, ".", _::binary>>, _} -> :inactive
     _ -> :global
   end)
+  |> Enum.map(fn {group_name, group_members} ->
+    {group_name, Enum.map(group_members, fn {k, v} -> %{key: k, value: v} end)}
+  end)
 
-Kino.DataTable.new(data.global)
-|> Kino.render
+Kino.DataTable.new(data[:global])
+|> Kino.render()
 
-Kino.DataTable.new(data.active)
-|> Kino.render
+Kino.DataTable.new(data[:active])
+|> Kino.render()
 
-Kino.DataTable.new(data.inactive)
-|> Kino.render
+Kino.DataTable.new(data[:inactive])
 ```


### PR DESCRIPTION
### Description

Currently in the diagnostics notebook, we parse the `Nerves.Runtime.KV.get_all` output into a map of group name to key-value tuple list. `Kino.DataTable.new` complains about that data structure. It seems `Kino.DataTable.new` no longer accepts a key-value tuple list although I had trouble finding exactly when this breaking change happened, quickly scanning [CHANGELOG](https://github.com/livebook-dev/kino/blob/main/CHANGELOG.md).

```elixir
Mix.install([
  {:kino, "~> 0.12.0"}
])
```

![nerves-livebook-diagnostics-notebook-error](https://github.com/nerves-livebook/nerves_livebook/assets/7563926/aad4df25-b133-465c-a357-241445c390a5)

### Fix

I added an extra step that converts all the key-value tuples to maps before rendering data tables.

![nerves-livebook-diagnostics-notebook-fixed 2024-01-14 at 15 25 34](https://github.com/nerves-livebook/nerves_livebook/assets/7563926/c3a47483-2430-4143-a453-5b3091ca7315)

### Notes

- The last `|> Kino.render` should be removed because Livebook implicitly does that for us. With that, we would end up getting a duplicated table.