### PR TITLE
Fix setup_wifi/0

### DIFF
--- a/lib/nerves_livebook/application.ex
+++ b/lib/nerves_livebook/application.ex
@@ -46,7 +46,7 @@ defmodule NervesLivebook.Application do
     defp setup_wifi() do
       kv = Nerves.Runtime.KV.get_all()
 
-      if true?(kv["wifi_force"]) or wlan0_unconfigured?() do
+      if true?(kv["wifi_force"]) or not wlan0_configured?() do
         ssid = kv["wifi_ssid"]
         passphrase = kv["wifi_passphrase"]
 
@@ -57,7 +57,7 @@ defmodule NervesLivebook.Application do
       end
     end
 
-    defp wlan0_unconfigured?() do
+    defp wlan0_configured?() do
       VintageNet.get_configuration("wlan0") |> VintageNetWiFi.network_configured?()
     catch
       _, _ -> false


### PR DESCRIPTION
### Description

When [vintage_net_wifi v0.12.4](https://github.com/nerves-networking/vintage_net_wifi/releases/tag/v0.12.4) was introduced with `VintageNetWiFi.network_configured?` at dc8c36a, the boolean output of `wlan0_unconfigured?/0` became reversed. This pull request will correct it.

Ideally, this pull request should be merged before releasing https://github.com/nerves-livebook/nerves_livebook/pull/524.

### Notes

- With this change, WiFi was able to get configured based on the values such as [`NERVES_WIFI_SSID`](https://github.com/nerves-livebook/nerves_livebook?tab=readme-ov-file#firmware-provisioning-options) provided when firmware is built. (tested with rpi4)
