### PR TITLE
partial fix for Issue 236: Adding github release info

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -90,7 +90,10 @@ config :livebook,
   rewrite_on: [],
   teams_auth?: false,
   teams_url: "https://teams.livebook.dev",
-  github_release_info: %{repo: "nerves-livebook/nerves_livebook", version: Mix.Project.config()[:version]},
+  github_release_info: %{
+    repo: "nerves-livebook/nerves_livebook",
+    version: Mix.Project.config()[:version]
+  },
   update_instructions_url: nil,
   within_iframe: false
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -90,6 +90,7 @@ config :livebook,
   rewrite_on: [],
   teams_auth?: false,
   teams_url: "https://teams.livebook.dev",
+  github_release_info: %{repo: "nerves-livebook/nerves_livebook", version: Mix.Project.config()[:version]},
   update_instructions_url: nil,
   within_iframe: false
 


### PR DESCRIPTION
The github release info will be picked up by the livebook update checker and will compare the compiled nerves project with the latest version of the correct repo

See discussion in [issue/236](https://github.com/nerves-livebook/nerves_livebook/issues/236) for more info and the current limitations