### PR TITLE
Add `rpi0_2` to the list of the device to match the release asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ devices:
 * `bbb` - BeagleBone Black, BeagleBone Green, PocketBeagle, etc.
 * `grisp2` - [GRiSP2](https://www.grisp.org/) (Experimental)
 * `rpi0` - Raspberry Pi Zero or Zero W
+* `rpi0_2` - Raspberry Pi Zero 2 W or Zero 2 W
 * `rpi` - The original Raspberry Pi Model B
 * `rpi2` Raspberry Pi 2 Model B
 * `rpi3` - Raspberry Pi 3 Model B and Model B+
-* `rpi3a` - Raspberry Pi 3 Model A+ and Raspberry Pi Zero 2 W
+* `rpi3a` - Raspberry Pi 3 Model A+ and Raspberry Pi Zero 2 W (32-bit mode)
 * `rpi4` - Raspberry Pi 4 Model B
 * `rpi5` - Raspberry Pi 5 Model B
 * `osd32mp1` - Octavo OSD32MP1-BRK


### PR DESCRIPTION
Hey all 👋 
new to the fantastic world of Nerves 🤩 
Thanks for the great work, i just bought a new RPi zero 2 W and I'm enjoying blinking leds.

If I don't mistake, in [v0.11.1](https://github.com/nerves-livebook/nerves_livebook/releases/tag/v0.11.1) rpi0 2 W has been added to supported the RPi targets (64-bit mode).

The PR updates the README to list it within the support devices to match the asset name in the release.
Based on my understanding before you could use the rpi3a firmware (32bit mode).

Cheers ✌️ 