### PR TITLE
Add stub Mix.install_project_dir to fix exception

### DIFF
--- a/lib/nerves_livebook/application.ex
+++ b/lib/nerves_livebook/application.ex
@@ -84,6 +84,10 @@ defmodule NervesLivebook.Application do
           def install(deps, opts \\\\ []) when is_list(deps) and is_list(opts) do
             NervesLivebook.MixInstall.install(deps, opts)
           end
+
+          def install_project_dir() do
+            NervesLivebook.MixInstall.install_project_dir()
+          end
         end
         """)
 

--- a/lib/nerves_livebook/mix_install.ex
+++ b/lib/nerves_livebook/mix_install.ex
@@ -14,6 +14,11 @@ defmodule NervesLivebook.MixInstall do
     |> Enum.each(&check_dep/1)
   end
 
+  @spec install_project_dir() :: Path.t()
+  def install_project_dir() do
+    "/data/.mix"
+  end
+
   defp normalize(app) when is_atom(app), do: {app, ">= 0.0.0"}
 
   defp normalize({app, opts}) when is_atom(app) and is_list(opts) do


### PR DESCRIPTION
This fixes:

```
Runtime terminated unexpectedly - an exception was raised:
    ** (UndefinedFunctionError) function Mix.install_project_dir/0 is undefined or private
        Mix.install_project_dir()
        (livebook 0.15.5) lib/livebook/runtime/erl_dist/runtime_server.ex:858: Livebook.Runtime.ErlDist.RuntimeServer.report_transient_state/1
        (livebook 0.15.5) lib/livebook/runtime/erl_dist/runtime_server.ex:406: Livebook.Runtime.ErlDist.RuntimeServer.handle_info/2
        (stdlib 6.2.1) gen_server.erl:2345: :gen_server.try_handle_info/3
        (stdlib 6.2.1) gen_server.erl:2433: :gen_server.handle_msg/6
        (stdlib 6.2.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

Fixes #633
